### PR TITLE
Limit max feed items on pelican.conf.py

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -25,6 +25,8 @@ SOCIAL = (
 
 DEFAULT_PAGINATION = 7
 
+FEED_MAX_ITEMS = 10
+
 import os.path
 THEME = os.path.join(os.getcwd(), 'ivory')
 


### PR DESCRIPTION
The all categories atom feed is gigantic and not parseable in some 
feed readers (see [1]). By default Pelican doesn't limit the number
of items in the feed, so using FEED_MAX_ITEMS (10 seems a good number).

[1] https://getsatisfaction.com/newsblur/topics/broken_feed_http_ivory_idyll_org_blog_feeds_all_atom_xml
